### PR TITLE
Menu not closing

### DIFF
--- a/src/app/components/main/main.ts
+++ b/src/app/components/main/main.ts
@@ -132,6 +132,7 @@ export class MainPage implements AfterViewInit {
   }
 
   openMenu() {
+  	document.getElementsByClassName("menu-inner")[0].style.display = "block";
     this.menuCtrl.open('menu1');
 
   }

--- a/src/app/components/menu/menu.html
+++ b/src/app/components/menu/menu.html
@@ -1,6 +1,6 @@
 <ion-menu side="start" swipeGesture="false"
 	contentId="menu1" menuId="menu1" 
-	(ionWillOpen)="menuOpened()" 
+	(ionWillOpen)="menuOpened()"
 	(ionWillClose)="menuClosed()"
 	type="overlay"
 	(swipeleft)="swipe($event)"
@@ -9,7 +9,7 @@
 	<ion-header>
 	  <ion-toolbar color="primary">
 			<ion-title>Osm Go !</ion-title>
-			<ion-menu-button class="menu-button">
+			<ion-menu-button class="menu-button" (click)="closeMenu()">
 				<ion-icon style="height: 56px;" name="arrow-back"></ion-icon> 
 			</ion-menu-button>
 	  </ion-toolbar>

--- a/src/app/components/menu/menu.ts
+++ b/src/app/components/menu/menu.ts
@@ -85,7 +85,9 @@ export class MenuPage {
     }
 
     closeMenu() {
-        this.menuCtrl.close();
+    	console.log("triggered");
+    	document.getElementsByClassName("menu-inner")[0].style.display = "none";
+        //this.menuCtrl.close();
     }
 
     logout() {


### PR DESCRIPTION
Today I provide a workaround for the bug described in issue #28 

This workaround removes the animation from the menu and takes a bit control back to the developer rather than fully relaying on the framework which I think is the issue. The menu is now opening and closing by just using truly javascript (no frameworks, no external libraries like JQuery) which I personally prefer. You should consider not to relay too much on the work from others. Too many dependencies increase the risk of breaking something in your code when the framework/library gets updated. A good practiseto overcome this issue is to include dependencies inside your repo or even better to provide a system which holds the dependencies for you on the state you need it.

Anyway you can add the animation code in `/src/app/components/menu` yourself by using truly CSS. You might want to read a [tutorial](https://www.w3schools.com/css/css3_animations.asp) if you don't know about how to create animations in truly CSS (like me).