### PR TITLE
Data Service performance optimizations

### DIFF
--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -8,8 +8,27 @@ import { OsmGoFeatureCollection, OsmGoFeature, FeatureIdSource } from 'src/type'
 @Injectable({ providedIn: 'root' })
 export class DataService {
     eventNewPage = new EventEmitter()
-    geojson: OsmGoFeatureCollection = DataService.makeEmptyGeoJsonFC()
-    geojsonChanged: OsmGoFeatureCollection = DataService.makeEmptyGeoJsonFC()
+
+    /**
+     * Primary data storage for official OSM POIs.
+     * Don't read from this value directly. Instead use the `geojson` member
+     * variable.
+     *
+     * A hashmap is used to have a constant time complexity when looking up
+     * entries with a known ID.
+     */
+    _geojson: Record<string, OsmGoFeature> = {}
+
+    /**
+     * Primary data storage for self-created or modified POIs.
+     * Don't read from this value directly. Instead use the `geojsonChanged`
+     * member variable.
+     *
+     * A hashmap is used to have a constant time complexity when looking up
+     * entries with a known ID.
+     */
+    _geojsonChanged: Record<string, OsmGoFeature> = {}
+
     geojsonWay: OsmGoFeatureCollection = DataService.makeEmptyGeoJsonFC()
     geojsonBbox: OsmGoFeatureCollection = DataService.makeEmptyGeoJsonFC()
 
@@ -17,6 +36,30 @@ export class DataService {
     private _nextFeatureId = 0
 
     constructor(public localStorage: Storage) {}
+
+    /**
+     * Getter that translates the internal storage representation of OSM POIs
+     * into a geojson feature collection.
+     *
+     * Data source is the `_geojson` member variable.
+     */
+    get geojson(): OsmGoFeatureCollection {
+        const fc = DataService.makeEmptyGeoJsonFC()
+        fc.features = Object.values(this._geojson)
+        return fc
+    }
+
+    /**
+     * Getter that translates the internal storage representation of
+     * self-created or modified POIs into a geojson feature collection.
+     *
+     * Data source is the `_geojsonChanged` member variable.
+     */
+    get geojsonChanged(): OsmGoFeatureCollection {
+        const fc = DataService.makeEmptyGeoJsonFC()
+        fc.features = Object.values(this._geojsonChanged)
+        return fc
+    }
 
     /** Creates a new GeoJSON feature collection that contains zero features. */
     static makeEmptyGeoJsonFC(): OsmGoFeatureCollection {
@@ -37,7 +80,9 @@ export class DataService {
         return from(this.localStorage.get('geojson')).pipe(
             map((geojson: OsmGoFeatureCollection) => {
                 geojson = geojson ? geojson : DataService.makeEmptyGeoJsonFC()
-                this.geojson = geojson
+                for (const feature of geojson.features) {
+                    this._geojson[feature.id] = feature
+                }
                 return geojson
             })
         )
@@ -47,7 +92,9 @@ export class DataService {
         return from(this.localStorage.get('geojsonChanged')).pipe(
             map((geojson: OsmGoFeatureCollection) => {
                 geojson = geojson ? geojson : DataService.makeEmptyGeoJsonFC()
-                this.geojsonChanged = geojson
+                for (const feature of geojson.features) {
+                    this._geojsonChanged[feature.id] = feature
+                }
 
                 // At this point we know previously created elements from which we can determine the min ID.
                 this._nextFeatureId =
@@ -137,33 +184,26 @@ export class DataService {
     }
 
     setGeojson(data: OsmGoFeatureCollection): void {
-        this.geojson = cloneDeep(data)
+        this._geojson = {}
+        for (const feature of data.features) {
+            this._geojson[feature.id] = cloneDeep(feature)
+        }
         this.localStorage.set('geojson', this.geojson)
     }
 
     addFeatureToGeojson(feature: OsmGoFeature): void {
-        this.geojson.features.push(feature)
+        this._geojson[feature.id] = feature
         this.setGeojson(this.geojson)
     }
 
     updateFeatureToGeojson(feature: OsmGoFeature): void {
-        for (let i = 0; i < this.geojson.features.length; i++) {
-            if (this.geojson.features[i].id === feature.id) {
-                this.geojson.features[i] = feature
-                this.setGeojson(this.geojson)
-                break
-            }
-        }
+        this._geojson[feature.id] = feature
+        this.setGeojson(this.geojson)
     }
 
     deleteFeatureFromGeojson(feature: OsmGoFeature): void {
-        for (let i = 0; i < this.geojson.features.length; i++) {
-            if (this.geojson.features[i].id === feature.id) {
-                this.geojson.features.splice(i, 1)
-                this.setGeojson(this.geojson)
-                break
-            }
-        }
+        delete this._geojson[feature.id]
+        this.setGeojson(this.geojson)
     }
 
     /**
@@ -205,8 +245,11 @@ export class DataService {
         return this._nextFeatureId--
     }
 
-    async setGeojsonChanged(geojson: OsmGoFeatureCollection): Promise<void> {
-        this.geojsonChanged = geojson
+    async setGeojsonChanged(data: OsmGoFeatureCollection): Promise<void> {
+        this._geojsonChanged = {}
+        for (const feature of data.features) {
+            this._geojsonChanged[feature.id] = cloneDeep(feature)
+        }
         await this.localStorage.set('geojsonChanged', this.geojsonChanged)
     }
 
@@ -237,45 +280,30 @@ export class DataService {
     }
 
     addFeatureToGeojsonChanged(feature: OsmGoFeature): Promise<any> {
-        this.geojsonChanged.features.push(feature)
+        this._geojsonChanged[feature.id] = feature
         return this.localStorage.set('geojsonChanged', this.geojsonChanged)
     }
 
     updateFeatureToGeojsonChanged(feature: OsmGoFeature): Promise<any> {
-        for (let i = 0; i < this.geojsonChanged.features.length; i++) {
-            if (this.geojsonChanged.features[i].id === feature.id) {
-                this.geojsonChanged.features[i] = feature
-            }
-        }
+        this._geojsonChanged[feature.id] = feature
         return this.localStorage.set('geojsonChanged', this.geojsonChanged)
     }
 
     deleteFeatureFromGeojsonChanged(feature: OsmGoFeature): Promise<any> {
-        for (let i = 0; i < this.geojsonChanged.features.length; i++) {
-            if (this.geojsonChanged.features[i].id === feature.id) {
-                this.geojsonChanged.features.splice(i, 1)
-                break
-            }
-        }
-
+        delete this._geojsonChanged[feature.id]
         return this.localStorage.set('geojsonChanged', this.geojsonChanged)
     }
 
     getMergedGeojsonGeojsonChanged(): OsmGoFeatureCollection {
         // stock les id dans un array
-        const changedIds = []
-        for (let i = 0; i < this.geojsonChanged.features.length; i++) {
-            changedIds.push(this.geojsonChanged.features[i].id)
-        }
+        const changedIds = Object.keys(this._geojsonChanged)
         // DELETE from GEOJSON
-        for (let i = this.geojson.features.length - 1; i >= 0; i--) {
-            if (changedIds.indexOf(this.geojson.features[i].id) !== -1) {
-                this.geojson.features.splice(i, 1)
-            }
+        for (const id of changedIds) {
+            delete this._geojson[id]
         }
         // ADD to geojson
-        for (let i = 0; i < this.geojsonChanged.features.length; i++) {
-            this.geojson.features.push(this.geojsonChanged.features[i])
+        for (const feature of Object.values(this._geojsonChanged)) {
+            this._geojson[feature.id] = feature
         }
         return cloneDeep(this.geojson)
     }
@@ -291,12 +319,13 @@ export class DataService {
 
     // supprime l'intégralité des changements
     async resetGeojsonChanged(): Promise<void> {
-        this.geojsonChanged = DataService.makeEmptyGeoJsonFC()
+        this._geojsonChanged = {}
         await this.localStorage.set('geojsonChanged', this.geojsonChanged)
         this._nextFeatureId = 0
     }
 
     resetGeojsonData(): OsmGoFeatureCollection {
+        this._geojson = {}
         this.setGeojson(DataService.makeEmptyGeoJsonFC())
         // this.getMergedGeojsonGeojsonChanged();
         // return this.getMergedGeojsonGeojsonChanged();

--- a/src/app/services/osmApi.service.ts
+++ b/src/app/services/osmApi.service.ts
@@ -562,7 +562,7 @@ export class OsmApiService {
     /// CREATE NODE
     createOsmNode(_feature) {
         const feature = cloneDeep(_feature)
-        const id = this.dataService.getNextNewId()
+        const id = this.dataService.nextFeatureId
 
         feature.id = 'node/' + id
         feature.properties.id = id


### PR DESCRIPTION
This PR introduces some performance optimizations for the data storage service.

1. Optimize performance when finding next free id
  Since DataService is a singleton, a new variable `_nextFeatureId` can be introduced which is always set to the next unused identifier. In case data is restored from cache, e.g., when reloading the application, the max ID can be restored from the restored entries by looping one time over all elements. Otherwise a simple member variable can be used to hold the next free ID without having to loop over all elements whenever a fresh ID is needed. This will improve performance - especially in cases where many elements are stored in the `geojsonCached` feature collection.
2. Use hashmap data structure
  This commit changes the underlying data structure of the `geojson` and `geojsonChanged` member variables. Instead of using an array a hashmap is being used. As a key, the feature ID is used. This speeds up and lookups and prevent the application from looping over potentially many elements at the cost of consuming a little bit more memory.

~~Changes depend on PR #120 which should be merged first. Unfortunately as a non-collaborator I cannot create branches in this repo. See my fork of this repo to diff branches against each other if needed.~~