### PR TITLE
Feature: Add GitHub CI Pipeline for Linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,17 @@
+name: 'Lint and static code analysis'
+
+on:
+  push:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint code style
+        run: npm run prettier:check

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,8 +1,16 @@
 {
-    "bracketSpacing": true,
-    "semi": false,
-    "singleQuote": true,
-    "trailingComma": "es5",
-    "printWidth": 80,
-    "tabWidth": 4
+  "bracketSpacing": true,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 80,
+  "tabWidth": 4,
+  "overrides": [
+    {
+      "files": ["*.yaml", "*.json"],
+      "options": {
+        "tabWidth": 2
+      }
+    }
+  ]
 }


### PR DESCRIPTION
This PR introduces a GitHub Action pipeline in which the code is linted with the `npm run prettier:check` command.
At the moment the pipeline fails - which makes sense since files have not yet been rewritten with prettier.

See [this example run](https://github.com/dotcs/OsmGo/runs/7148149864?check_suite_focus=true) output for details.