### PR TITLE
Simpler way to use Osm Go in a subdirectory

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,10 +2,10 @@ name: Deployment
 
 on:
   push:
-    # branches:
-    #   - main
-    # tags:
-    #   - '[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - main
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   deployment:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,10 +2,10 @@ name: Deployment
 
 on:
   push:
-    branches:
-      - main
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+    # branches:
+    #   - main
+    # tags:
+    #   - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   deployment:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
         run: npm run test:ci
 
       - name: Create build
-        run: npm run build
+        run: ng build --configuration production --base-href=/OsmGo/
 
       - name: Deploy
         if: success()

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
         run: npm run test:ci
 
       - name: Create build
-        run: ng build --configuration production --base-href=/OsmGo/
+        run: npm run ng -- build --configuration production --base-href=/OsmGo/
 
       - name: Deploy
         if: success()

--- a/src/app/components/icon/icon.component.scss
+++ b/src/app/components/icon/icon.component.scss
@@ -1,9 +1,9 @@
 .spritesX1 {
-    background: url('/assets/iconsSprites@x1.png') 0 0 no-repeat;
+    background: url('../../../assets/iconsSprites@x1.png') 0 0 no-repeat;
 }
 
 .spritesX2 {
-    background: url('/assets/iconsSprites@x2.png') 0 0 no-repeat;
+    background: url('../../../assets/iconsSprites@x2.png') 0 0 no-repeat;
 }
 
 .iconWrapper {

--- a/src/app/components/modal/modal.html
+++ b/src/app/components/modal/modal.html
@@ -159,7 +159,7 @@
                         size="small"
                         (click)="saveFields(tagId, tags)"
                     >
-                        <ion-icon src="/assets/fa/copy-solid.svg"></ion-icon>
+                        <ion-icon src="./assets/fa/copy-solid.svg"></ion-icon>
                     </ion-fab-button>
                 </ion-fab>
 
@@ -168,7 +168,7 @@
                         size="small"
                         (click)="restoreFields(tagId, tags)"
                     >
-                        <ion-icon src="/assets/fa/paste-solid.svg"></ion-icon>
+                        <ion-icon src="./assets/fa/paste-solid.svg"></ion-icon>
                     </ion-fab-button>
                 </ion-fab>
             </div>

--- a/src/app/services/map.service.ts
+++ b/src/app/services/map.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, EventEmitter, NgZone } from '@angular/core'
+import { Injectable, EventEmitter, NgZone, Inject } from '@angular/core'
 import { DataService } from '@services/data.service'
 import { TagsService } from '@services/tags.service'
 import { AlertService } from '@services/alert.service'
@@ -171,19 +171,19 @@ export class MapService {
     loadUnknownMarker(factor: number): void {
         const roundedFactor = factor > 1 ? 2 : 1
         this.map.loadImage(
-            `/assets/mapStyle/unknown-marker/circle-unknown@${roundedFactor}X.png`,
+            `./assets/mapStyle/unknown-marker/circle-unknown@${roundedFactor}X.png`,
             (error, image) => {
                 this.markerMaplibreUnknown['circle'] = image
             }
         )
         this.map.loadImage(
-            `/assets/mapStyle/unknown-marker/penta-unknown@${roundedFactor}X.png`,
+            `./assets/mapStyle/unknown-marker/penta-unknown@${roundedFactor}X.png`,
             (error, image) => {
                 this.markerMaplibreUnknown['penta'] = image
             }
         )
         this.map.loadImage(
-            `/assets/mapStyle/unknown-marker/square-unknown@${roundedFactor}X.png`,
+            `./assets/mapStyle/unknown-marker/square-unknown@${roundedFactor}X.png`,
             (error, image) => {
                 this.markerMaplibreUnknown['square'] = image
             }
@@ -553,8 +553,8 @@ export class MapService {
         return this.http.get('assets/mapStyle/brigthCustom.json').pipe(
             map((maplibreStyle) => {
                 let spritesFullPath = `mapStyle/sprites/sprites`
-                // http://localhost:8100/assets/mapStyle/sprites/sprites.json
-                const basePath = window.location.origin // path.split('#')[0];
+
+                const basePath = window.location.href.split('#')[0] //example : http://127.0.0.1:8080/www/#/main => http://127.0.0.1:8080/www/
                 spritesFullPath = `${basePath}/assets/${spritesFullPath}`
 
                 maplibreStyle['sprite'] = spritesFullPath

--- a/src/assets/mapStyle/brigthCustom.json
+++ b/src/assets/mapStyle/brigthCustom.json
@@ -72,12 +72,12 @@
     "pitch": 0,
     "sources": {
         "composite": {
-            "url": "assets/mapStyle/mapbox.mapbox-streets-v7.json",
+            "url": "./assets/mapStyle/mapbox.mapbox-streets-v7.json",
             "type": "vector"
         }
     },
-    "sprite": "assets/mapStyle/sprites",
-    "glyphs": "assets/mapStyle/glyphs/{fontstack}/{range}.pbf",
+    "sprite": "./assets/mapStyle/sprites",
+    "glyphs": "./assets/mapStyle/glyphs/{fontstack}/{range}.pbf",
     "layers": [
         {
             "id": "background",

--- a/src/manifest.webmanifest
+++ b/src/manifest.webmanifest
@@ -5,8 +5,8 @@
     "theme_color": "#1976d2",
     "background_color": "#fafafa",
     "display": "standalone",
-    "scope": "/",
-    "start_url": "/",
+    "scope": "./",
+    "start_url": "./index.html",
     "icons": [
         {
             "src": "assets/icons/icon-72x72.png",


### PR DESCRIPTION
Change some absolute paths to relative.

For Osm Go to work with a subdirectory, we need to add the --base-href parameter to ng build

Example : ng build --configuration production --base-href=/OsmGo/

We can test this locally,
```sh
ng build --configuration production --base-href=/www/
```
for example with http-server 
In root directory :  http-server .

"http://127.0.0.1:8080/www/ "  should work
